### PR TITLE
docs: add missing closing quotation mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
 | Input                                             | Description                                        |
 |------------------------------------------------------|-----------------------------------------------|
 | `pull_request_template_path`  | Path to the pull request template used by the repository (defailt value: .github/pull_request_template.md)    |
-| `max_pull_request_description_match  | Value between 0-1 to indicate how similar the pull request body/description is allowed to be with the template (default value: 0.7) |
+| `max_pull_request_description_match`  | Value between 0-1 to indicate how similar the pull request body/description is allowed to be with the template (default value: 0.7) |
 
 ### Outputs
 


### PR DESCRIPTION
Add missing ` character on input description
